### PR TITLE
Add caster.link

### DIFF
--- a/_data/projects/che_cs_club/caster.link.yml
+++ b/_data/projects/che_cs_club/caster.link.yml
@@ -1,0 +1,8 @@
+name: caster.link
+description: Web-based live streaming for mobile devices. Compatible with Chrome and Firefox. Site/streaming may be down, we're trying to get our server fixed.
+url: http://caster.link
+github_url: https://github.com/jawerty/caster.link
+authors:
+  - Bogdan Vitoc
+  - Jared Wright
+  - Evan Klein


### PR DESCRIPTION
Project details:

* Club: CHE CS Club
* Name: caster.link
* Description: Web-based live streaming for mobile devices. Compatible with Chrome and Firefox. Site/streaming may be down, we're trying to get our server fixed.
* URL: http://caster.link
* GitHub: https://github.com/jawerty/caster.link
* Authors:
  * Bogdan Vitoc
  * Jared Wright
  * Evan Klein


:shipit: