### PR TITLE
Fix CI build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,9 @@
 FROM jekyll/jekyll
 MAINTAINER Zach Latta <zach@hackedu.us>
 
+RUN rm -rf /srv/jekyll/
 COPY . /srv/jekyll/
+RUN chown -R jekyll:jekyll /srv/jekyll/
 
 EXPOSE 8080
 ENTRYPOINT ["jekyll", "serve", "-P", "8080"]


### PR DESCRIPTION
It seems that the jekyll/jekyll Docker image changed upstream to include
files in /srv/jekyll by default, breaking our build. This change clears
those files before adding the project's files to the image, fixing the
build.