### PR TITLE
Delete Just Click the Link. Closes #78.

### DIFF
--- a/_data/projects/hack_camp/just_click_the_link.yml
+++ b/_data/projects/hack_camp/just_click_the_link.yml
@@ -1,6 +1,0 @@
-name: Just Click the Link
-description: JUST DO IT!
-url: https://unitytest-matthewgaim.c9.io/index.html
-github_url: https://ide.c9.io/matthewgaim/unitytest
-authors:
-  - Matthew Gaim


### PR DESCRIPTION
This change deletes Just Click the Link because many schools may find it inappropriate.

I submitted this PR instead of merging #78 because the file needs to be completely removed for the build to still work, not to be emptied.